### PR TITLE
ci: update github token reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
       - run: pnpm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Update CI configuration to use GH_TOKEN instead of GITHUB_TOKEN

Link to Devin run: https://app.devin.ai/sessions/4162e26a77c243939a40b2268f7542df